### PR TITLE
Add RoomTreat Absorption Coefficients dataset (Databases)

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1,4 +1,10 @@
 [
+    {
+    "name": "RoomTreat Absorption Coefficients",
+    "url": "https://roomtreat.com/data/absorption-coefficients/",
+    "description": "60 building & acoustic materials — octave-band sound absorption coefficients + NRC, sourced, CSV, CC BY 4.0",
+    "category": "Databases"
+  },
   {
     "name": "Acoustic Toolbox",
     "url": "https://github.com/Universite-Gustave-Eiffel/acoustic-toolbox",


### PR DESCRIPTION
- 60 building & acoustic-treatment materials; octave-band absorption coefficients (125–4000 Hz) + NRC
- Aggregated and cited from standard references (Vorländer; Cox & D'Antonio; Bies & Hansen; Beranek & Mellow; ISO 354 / ASTM C423 tables); downloadable CSV
- License: CC BY 4.0

Disclosure: I compiled and maintain this dataset and the free, vendor-neutral tools at roomtreat.com (I don't sell acoustic products). Coefficients are aggregated and cited from standard references, not original measurements — corrections welcome.

Fits the existing Databases section alongside external datasets like xeno-canto and The International Soundscape Database.