### PR TITLE
Rename PyOctaveBand to phonometry

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -34,9 +34,9 @@
     "techs": "Python"
   },
   {
-    "name": "PyOctaveBand",
-    "url": "https://github.com/jmrplens/PyOctaveBand",
-    "description": "[Python3] Octave-Band and Fractional Octave-Band filter. For signal in time domain.",
+    "name": "phonometry",
+    "url": "https://github.com/jmrplens/phonometry",
+    "description": "Acoustic measurement, analysis and prediction in Python (formerly PyOctaveBand). Every metric is implemented from the text of its governing standard and checked in CI against that standard's own tolerance tables and worked examples.",
     "category": "Signal Processing",
     "techs": "Python"
   },


### PR DESCRIPTION
I renamed this project at version 3.0.0. The old repository still redirects, so the current link works, but the entry now points at a name that no longer exists and describes a scope the library outgrew.

The library began as an octave-band and fractional octave-band filter. It now covers sound level metrology, psychoacoustics, room and building acoustics, materials, vibration, environmental, aircraft and underwater noise, electroacoustics and FDTD wave simulation, with every metric implemented from the text of its governing standard and checked in CI against that standard's own tolerance tables and worked examples.

Following CONTRIBUTING.md, I only edited `projects.json` and left `detailed_projects.json` and `README.md` for the action to regenerate. Since the URL now points at the current repository, the enrichment script will also pick up the up to date GitHub metadata, which the old URL could not.

I kept the entry in Signal Processing. Several other categories in the list would fit it too, but I would rather not spread one project across sections in a PR of my own.

Links: [repository](https://github.com/jmrplens/phonometry), [documentation](https://jmrplens.github.io/phonometry/), [PyPI](https://pypi.org/project/phonometry/).
